### PR TITLE
Remove build on start

### DIFF
--- a/docker/scripts/workspace-entrypoint.sh
+++ b/docker/scripts/workspace-entrypoint.sh
@@ -14,19 +14,20 @@ source /opt/ros/${ROS_DISTRO}/setup.bash
 
 sudo apt-get update
 rosdep update
+rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y --skip-keys "nvblox"
 
 # Restart udev daemon
 sudo service udev restart
 
 # Build and source the workspace
-cd /workspaces/isaac_ros-dev && \
-colcon build --symlink-install && \
-source install/setup.bash
+# cd /workspaces/isaac_ros-dev && \
+# colcon build --symlink-install && \
+# source install/setup.bash
 
 # Automatically launch the apriltags package
 #ros2 launch isaac_ros_apriltag isaac_ros_apriltag_realsense.launch.py
 
 # Automatically launch the nvblox package
-ros2 launch nvblox_nav2 nvblox_launch.py
+# ros2 launch nvblox_nav2 nvblox_launch.py
 
 $@


### PR DESCRIPTION
Build on start is slow and uneeded and will break systems where certain packages are not supported